### PR TITLE
Remove crispy_forms dependancy

### DIFF
--- a/paperclip/__init__.py
+++ b/paperclip/__init__.py
@@ -1,8 +1,18 @@
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 
 app_settings = dict({
     'FILETYPE_MODEL': 'FileType',
     'ATTACHMENT_TABLE_NAME': 'paperclip_attachment',
     'ACTION_HISTORY_ENABLED': True,
+    'USE_CRISPY_FORMS': True
 }, **getattr(settings, 'PAPERCLIP_CONFIG', {}))
+
+if app_settings['USE_CRISPY_FORMS']:
+    try:
+        import crispy_forms
+    except ImportError:
+        raise ImproperlyConfigured(
+            "Please install django_crispy_forms or "
+            "set USE_CRISPY_FORMS to False in your PAPERCLIP_CONFIG setting.")

--- a/paperclip/templates/paperclip/_attachment_form_no_crispy.html
+++ b/paperclip/templates/paperclip/_attachment_form_no_crispy.html
@@ -1,0 +1,27 @@
+{% load i18n %}
+
+<h4>{{ form_title }}</h4>
+
+{{ form.media }}
+
+<form action="{{ attachment_form.form_url }}"
+      enctype="multipart/form-data"
+      method="post">
+  {% csrf_token %}
+
+  {{ attachment_form.as_p }}
+
+  {% if attachment_form.is_creation %}
+      <input type="submit"
+             id="submit_attachment"
+             name="submit_attachment"
+             value="{% trans "Submit attachment" %}"/>
+  {% else %}
+      <input type="button"
+             value="{% trans "Cancel" %}"/>
+      <input type="submit"
+             id="submit_attachment"
+             name="submit_attachment"
+             value="{% trans "Update attachment" %}"/>
+  {% endif %}
+</form> 

--- a/paperclip/templatetags/attachments_tags.py
+++ b/paperclip/templatetags/attachments_tags.py
@@ -5,7 +5,9 @@ from django.utils.translation import ugettext_lazy as _
 
 from paperclip.forms import AttachmentForm
 from paperclip.models import Attachment
+from paperclip import app_settings
 
+USE_CRISPY_FORMS = app_settings['USE_CRISPY_FORMS']
 
 register = Library()
 
@@ -19,7 +21,13 @@ def icon_name(value):
     return ext[1:] if ext else 'bin'
 
 
-@register.inclusion_tag('paperclip/_attachment_form.html', takes_context=True)
+if USE_CRISPY_FORMS:
+    attachment_form_tpl_name = 'paperclip/_attachment_form.html'
+else:
+    attachment_form_tpl_name = 'paperclip/_attachment_form_no_crispy.html'
+
+
+@register.inclusion_tag(attachment_form_tpl_name, takes_context=True)
 def attachment_form(context, obj, form=None):
     """
     Renders a "upload attachment" form.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         'Django',
         'django-floppyforms',
         'easy-thumbnails',
-        'django-crispy-forms',
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Add a way to get rid of crispy_forms:
- Add a setting USE_CRISPY_FORMS : boolean (True by default to not break existing installations)
- Add a template _attachment_form_no_crispy.html (templatetag smartly use _attachment_form.html or _attachment_form_no_crispy.html based on USE_CRISPY_FORMS value)
- Adapt form **init** method to not create Layout if USE_CRISPY_FORM is not used
- Remove crispy_forms from requirements in setup.py
- Raise an ImproperlyConfigured exception if USE_CRISPY_FORMS is True but module is not installed

This works well without crispy_forms but I think the code needs review (and test) for a "with crispy_forms" usage even if I tried to not break anything.
